### PR TITLE
Add os packages for JDK16

### DIFF
--- a/jdk16/Dockerfile
+++ b/jdk16/Dockerfile
@@ -9,7 +9,7 @@ ENV LANG C.UTF-8
 RUN set -eux; \
     apt-get update \
     && apt-get upgrade --yes --no-install-recommends \
-    ; \
+    binutils fakeroot; \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \


### PR DESCRIPTION
JDK16 needs for `jlink` und `jpackage` some os packages.

> Most desktop installations will already have the libraries required by the JDK tools, but the jlink and jpackage programs require two additional packages when they run outside of the Snap package container. They both need the objcopy program from the binutils package to create the custom runtime image, and jpackage needs the fakeroot package to create a Debian package.

https://github.com/jgneff/openjdk